### PR TITLE
Mention git submodules in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 Bindings to the official [brotli] implementation in Rust.
 
+Note that you should clone this repository with `git clone --recursive`, to include the referenced C implementation.
+
 [brotli]: https://github.com/google/brotli
 
 ```toml


### PR DESCRIPTION
Maybe this is too obvious to people used to git, but the build error if you don't do it is a little confusing.
