### PR TITLE
Modified the build script to try and locate the git executable on Windows.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/alexcrichton/brotli-rs"
-homepage = "https://github.com/alexcrichton/brotli-rs"
-documentation = "http://alexcrichton.com/brotli-rs"
+repository = "https://github.com/alexcrichton/brotli2-rs"
+homepage = "https://github.com/alexcrichton/brotli2-rs"
+documentation = "http://alexcrichton.com/brotli2-rs"
 description = """
 Bindings to libbrotli to provide brotli decompression and compression to Rust
 """

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/alexcrichton/brotli-rs.svg?branch=master)](https://travis-ci.org/alexcrichton/brotli-rs)
 [![Build status](https://ci.appveyor.com/api/projects/status/j58d3x8p0a8mig0m?svg=true)](https://ci.appveyor.com/project/alexcrichton/brotli-rs)
 
-[Documentation](http://alexcrichton.com/brotli-rs)
+[Documentation](http://alexcrichton.com/brotli2-rs)
 
 Bindings to the official [brotli] implementation in Rust.
 

--- a/brotli-sys/Cargo.toml
+++ b/brotli-sys/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 build = "build.rs"
 links = "brotli"
 license = "MIT/Apache-2.0"
-repository = "https://github.com/alexcrichton/brotli-rs"
-homepage = "https://github.com/alexcrichton/brotli-rs"
-documentation = "http://alexcrichton.com/brotli-rs"
+repository = "https://github.com/alexcrichton/brotli2-rs"
+homepage = "https://github.com/alexcrichton/brotli2-rs"
+documentation = "http://alexcrichton.com/brotli2-rs"
 description = """
 Raw bindings to libbrotli
 """

--- a/brotli-sys/Cargo.toml
+++ b/brotli-sys/Cargo.toml
@@ -25,3 +25,7 @@ libc = "0.2"
 
 [build-dependencies]
 gcc = "0.3"
+
+[target.'cfg(windows)'.build-dependencies]
+winapi = "0.2"
+winreg = "0.3"

--- a/brotli-sys/build.rs
+++ b/brotli-sys/build.rs
@@ -1,13 +1,77 @@
 extern crate gcc;
+#[cfg(windows)]
+extern crate winapi;
+#[cfg(windows)]
+extern crate winreg;
 
 use std::env;
 use std::process::Command;
 use std::path::Path;
 
+#[cfg(windows)]
+mod find_git {
+    use std::ffi::OsStr;
+    use std::io::Result;
+    use std::path::PathBuf;
+    use std::process::Command;
+    use winapi::HKEY;
+    use winreg::RegKey;
+    use winreg::enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE, KEY_READ};
+
+    fn try_git_path<P: AsRef<OsStr>>(predefined_key: HKEY,
+                                     subkey_path: P,
+                                     value: P)
+                                     -> Option<PathBuf> {
+        let root = RegKey::predef(predefined_key);
+        if let Ok(subkey) = root.open_subkey_with_flags(subkey_path, KEY_READ) {
+            let subkey_value: Result<String> = subkey.get_value(value);
+            if let Ok(install_path) = subkey_value {
+                let binary_path = PathBuf::from(&install_path).join("bin").join("git.exe");
+                if Command::new(&binary_path).args(&["--version"]).status().is_ok() {
+                    return Some(binary_path);
+                }
+            }
+        }
+        None
+    }
+
+    pub fn git_path() -> PathBuf {
+        if Command::new("git").args(&["--version"]).status().is_ok() {
+            return PathBuf::from("git");
+        }
+        try_git_path(HKEY_LOCAL_MACHINE, "Software\\GitForWindows", "InstallPath").or_else(|| {
+            try_git_path(HKEY_CURRENT_USER,
+                         "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Git_is1",
+                         "InstallLocation")
+        }).or_else(|| {
+            try_git_path(HKEY_CURRENT_USER,
+                         "SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Git_is1",
+                         "InstallLocation")
+        }).or_else(|| {
+            try_git_path(HKEY_LOCAL_MACHINE,
+                         "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Git_is1",
+                         "InstallLocation")
+        }).or_else(|| {
+            try_git_path(HKEY_LOCAL_MACHINE,
+                         "SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Git_is1",
+                         "InstallLocation")
+        }).expect("Failed to locate Git executable.")
+    }
+}
+
+#[cfg(windows)]
+use find_git::git_path;
+
+#[cfg(not(windows))]
+fn git_path() -> ::std::path::PathBuf {
+    ::std::path::PathBuf::from("git")
+}
+
 fn main() {
     if !Path::new("brotli/.git").exists() {
-        let _ = Command::new("git").args(&["submodule", "update", "--init"])
-                                   .status();
+        let _ = Command::new(git_path())
+                    .args(&["submodule", "update", "--init"])
+                    .status();
     }
 
     let src = env::current_dir().unwrap();


### PR DESCRIPTION
On Windows, Git is often installed without modifying `%PATH%` (the installer lists this as the safest option).

This PR changes `build.rs` so that if the unadorned Git command fails on Windows it tries five known registry keys to locate the binary.

By the way, there's a typo ("decoers") in your repo's description.
