### PR TITLE
set_params is (semi)-broken

### DIFF
--- a/src/bufread.rs
+++ b/src/bufread.rs
@@ -51,7 +51,7 @@ impl<R: BufRead> BrotliEncoder<R> {
         let mut data = Compress::new();
         data.set_params(params);
         BrotliEncoder {
-            buf: Cursor::new(Vec::with_capacity(params.get_lgwin())),
+            buf: Cursor::new(Vec::with_capacity(params.get_lgwin_readable())),
             obj: r,
             max: data.input_block_size(),
             cur: 0,

--- a/src/bufread.rs
+++ b/src/bufread.rs
@@ -37,7 +37,7 @@ impl<R: BufRead> BrotliEncoder<R> {
         let mut data = Compress::new();
         data.set_params(CompressParams::new().quality(level));
         BrotliEncoder {
-            buf: Cursor::new(Vec::with_capacity(data.get_lgwin())),
+            buf: Cursor::new(Vec::new()),
             obj: r,
             max: data.input_block_size(),
             cur: 0,
@@ -51,7 +51,7 @@ impl<R: BufRead> BrotliEncoder<R> {
         let mut data = Compress::new();
         data.set_params(params);
         BrotliEncoder {
-            buf: Cursor::new(Vec::with_capacity(data.get_lgwin())),
+            buf: Cursor::new(Vec::with_capacity(params.get_lgwin())),
             obj: r,
             max: data.input_block_size(),
             cur: 0,

--- a/src/bufread.rs
+++ b/src/bufread.rs
@@ -37,18 +37,27 @@ impl<R: BufRead> BrotliEncoder<R> {
         let mut data = Compress::new();
         data.set_params(CompressParams::new().quality(level));
         BrotliEncoder {
+            buf: Cursor::new(Vec::with_capacity(data.get_lgwin())),
             obj: r,
             max: data.input_block_size(),
             cur: 0,
             data: data,
-            buf: Cursor::new(Vec::new()),
             done: false,
         }
     }
 
     /// Creates a new encoder with a custom `CompressParams`.
-    pub fn set_params(&mut self, params: &CompressParams) {
-        self.data.set_params(params);
+    pub fn from_params(r: R, params: &CompressParams) -> BrotliEncoder<R> {
+        let mut data = Compress::new();
+        data.set_params(params);
+        BrotliEncoder {
+            buf: Cursor::new(Vec::with_capacity(data.get_lgwin())),
+            obj: r,
+            max: data.input_block_size(),
+            cur: 0,
+            data: data,
+            done: false,
+        }
     }
 
     /// Acquires a reference to the underlying stream

--- a/src/read.rs
+++ b/src/read.rs
@@ -33,7 +33,7 @@ impl<R: Read> BrotliEncoder<R> {
     pub fn from_params( r: R, params: &CompressParams) -> BrotliEncoder<R> {
         BrotliEncoder{
             inner: bufread::BrotliEncoder::from_params(
-                BufReader::with_capacity(params.get_lgwin(),r), params)
+                BufReader::with_capacity(params.get_lgwin_readable(),r), params)
         }
     }
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -30,8 +30,11 @@ impl<R: Read> BrotliEncoder<R> {
     }
 
     /// Configure the compression parameters of this encoder.
-    pub fn set_params(&mut self, params: &CompressParams) {
-        self.inner.set_params(params);
+    pub fn from_params( r: R, params: &CompressParams) -> BrotliEncoder<R> {
+        BrotliEncoder{
+            inner: bufread::BrotliEncoder::from_params(
+                BufReader::with_capacity(params.get_lgwin(),r), params)
+        }
     }
 
     /// Acquires a reference to the underlying stream

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -470,12 +470,25 @@ impl CompressParams {
     }
 
     /// Get the current block size
-    pub fn get_lgblock(&self) -> usize {
+    #[inline]
+    pub fn get_lgblock_readable(&self) -> usize {
         1usize << self.lgblock
     }
+
+    /// Get the native lgblock size
+    #[inline]
+    pub fn get_lgblock(&self) -> u32 {
+        self.lgblock.clone()
+    }
     /// Get the current window size
-    pub fn get_lgwin(&self) -> usize {
+    #[inline]
+    pub fn get_lgwin_readable(&self) -> usize {
         1usize << self.lgwin
+    }
+    /// Get the native lgwin value
+    #[inline]
+    pub fn get_lgwin(&self) -> u32 {
+        self.lgwin.clone()
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -32,6 +32,7 @@ unsafe impl Send for Compress {}
 unsafe impl Sync for Compress {}
 
 /// Parameters passed to various compression routines.
+#[derive(Clone,Debug)]
 pub struct CompressParams {
     /// Compression mode.
     mode: u32,
@@ -46,6 +47,8 @@ pub struct CompressParams {
 }
 
 /// Possible choices for modes of compression
+#[repr(isize)]
+#[derive(Copy,Clone,Debug)]
 pub enum CompressMode {
     /// Default compression mode, the compressor does not know anything in
     /// advance about the properties of the input.

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -465,6 +465,15 @@ impl CompressParams {
         self.lgblock = lgblock;
         self
     }
+
+    /// Get the current block size
+    pub fn get_lgblock(&self) -> usize {
+        1usize << self.lgblock
+    }
+    /// Get the current window size
+    pub fn get_lgwin(&self) -> usize {
+        1usize << self.lgwin
+    }
 }
 
 impl fmt::Display for Error {

--- a/src/write.rs
+++ b/src/write.rs
@@ -38,8 +38,15 @@ impl<W: Write> BrotliEncoder<W> {
     }
 
     /// Creates a new encoder with a custom `CompressParams`.
-    pub fn set_params(&mut self, params: &CompressParams) {
-        self.data.set_params(params);
+    pub fn from_params(obj: W, params: &CompressParams) -> BrotliEncoder<W> {
+        let mut data = Compress::new();
+        data.set_params(params);
+        BrotliEncoder {
+            max: data.input_block_size(),
+            cur: 0,
+            data: data,
+            obj: Some(obj)
+        }
     }
 
 


### PR DESCRIPTION
Issue:

The data placed into `CompressParams` doesn't always apply to the underlying compressor. 

Example:
```rust
let mut p = CompressParams::new();
p.mode(CompressMode::Text);
p.quality(11);
p.lgwin(24);
p.lgblock(24);
let mut r = BrotliEncoder::new(r, 6);
r.set_params(p);

/* Do encryption */
```

The above code will give the same result as if `set_params` is never called. Ultimately the only _tunable_ for Read/Write/BufReader objects are the created `level: u32` value. 

This patch proposes a change in API instead of 

```rust
let mut e = Encoder::new();
e.set_params();
```

This would do

```rust
let mut e = Encoder::from_params(r, params);
```

This patch fixes the issue as is. 