### PR TITLE
Upgrade brotli to 0.6.0

### DIFF
--- a/brotli-sys/build.rs
+++ b/brotli-sys/build.rs
@@ -11,22 +11,24 @@ fn main() {
     }
 
     let src = env::current_dir().unwrap();
-    println!("cargo:dec_include={}", src.join("brotli/dec").display());
-    println!("cargo:enc_include={}", src.join("brotli/enc").display());
+    println!("cargo:include={}", src.join("brotli/include").display());
 
     gcc::Config::new()
+        .include("brotli/include")
         .file("brotli/common/dictionary.c")
         .file("brotli/dec/bit_reader.c")
         .file("brotli/dec/decode.c")
         .file("brotli/dec/huffman.c")
         .file("brotli/dec/state.c")
         .file("brotli/enc/backward_references.c")
+        .file("brotli/enc/backward_references_hq.c")
         .file("brotli/enc/bit_cost.c")
         .file("brotli/enc/block_splitter.c")
         .file("brotli/enc/brotli_bit_stream.c")
         .file("brotli/enc/cluster.c")
         .file("brotli/enc/compress_fragment.c")
         .file("brotli/enc/compress_fragment_two_pass.c")
+        .file("brotli/enc/dictionary_hash.c")
         .file("brotli/enc/encode.c")
         .file("brotli/enc/entropy_encode.c")
         .file("brotli/enc/histogram.c")

--- a/brotli-sys/src/lib.rs
+++ b/brotli-sys/src/lib.rs
@@ -3,7 +3,7 @@
 
 extern crate libc;
 
-use libc::{c_void, size_t, c_int};
+use libc::{c_void, size_t, c_int, c_char};
 
 #[cfg(target_env = "msvc")]
 #[doc(hidden)]
@@ -12,197 +12,81 @@ pub type __enum_ty = libc::c_int;
 #[doc(hidden)]
 pub type __enum_ty = libc::c_uint;
 
-pub type brotli_alloc_func = extern fn(*mut c_void, size_t) -> *mut c_void;
-pub type brotli_free_func = extern fn(*mut c_void, *mut c_void);
+pub type __enum_ty_s = libc::c_int;
+
+pub type brotli_alloc_func = Option<extern "C" fn(*mut c_void, size_t) -> *mut c_void>;
+pub type brotli_free_func = Option<extern "C" fn(*mut c_void, *mut c_void)>;
 
 // ========== Decoder functionality ==========
 
-pub type BrotliResult = __enum_ty;
-pub type BrotliRunningState = __enum_ty;
-pub type BrotliRunningMetablockHeaderState = __enum_ty;
-pub type BrotliRunningUncompressedState = __enum_ty;
-pub type BrotliRunningTreeGroupState = __enum_ty;
-pub type BrotliRunningContextMapState = __enum_ty;
-pub type BrotliRunningHuffmanState = __enum_ty;
-pub type BrotliRunningDecodeUint8State = __enum_ty;
-pub type BrotliRunningReadBlockLengthState = __enum_ty;
+pub type BrotliDecoderResult = __enum_ty;
+pub type BrotliDecoderErrorCode = __enum_ty_s;
 
-pub type BrotliState = BrotliStateStruct;
+pub enum BrotliDecoderState {}
 
-#[repr(C)]
-pub struct BrotliStateStruct {
-    pub state: BrotliRunningState,
-    pub loop_counter: c_int,
-    pub br: BrotliBitReader,
-    pub alloc_func: Option<brotli_alloc_func>,
-    pub free_func: Option<brotli_free_func>,
-    pub memory_manager_opaque: *mut c_void,
-    buffer: u64,
-    pub buffer_length: u32,
-    pub pos: c_int,
-    pub max_backward_distance: c_int,
-    pub max_backward_distance_minus_custom_dict_size: c_int,
-    pub max_distance: c_int,
-    pub ringbuffer_size: c_int,
-    pub ringbuffer_mask: c_int,
-    pub dist_rb_idx: c_int,
-    pub dist_rb: [c_int; 4],
-    pub error_code: c_int,
-    pub sub_loop_counter: u32,
-    pub ringbuffer: *mut u8,
-    pub ringbuffer_end: *mut u8,
-    pub htree_command: *mut HuffmanCode,
-    pub context_lookup1: *const u8,
-    pub context_lookup2: *const u8,
-    pub context_map_slice: *mut u8,
-    pub dist_context_map_slice: *mut u8,
-    pub literal_hgroup: HuffmanTreeGroup,
-    pub insert_copy_hgroup: HuffmanTreeGroup,
-    pub distance_hgroup: HuffmanTreeGroup,
-    pub block_type_trees: *mut HuffmanCode,
-    pub block_len_trees: *mut HuffmanCode,
-    pub trivial_literal_context: c_int,
-    pub distance_context: c_int,
-    pub meta_block_remaining_len: c_int,
-    pub block_length_index: u32,
-    pub block_length: [u32; 3],
-    pub num_block_types: [u32; 3],
-    pub block_type_rb: [u32; 6],
-    pub distance_postfix_bits: u32,
-    pub num_direct_distance_codes: u32,
-    pub distance_postfix_mask: c_int,
-    pub num_dist_htrees: u32,
-    pub dist_context_map: *mut u8,
-    pub literal_htree: *mut HuffmanCode,
-    pub dist_htree_index: u8,
-    pub repeat_code_len: u32,
-    pub prev_code_len: u32,
-    pub copy_length: c_int,
-    pub distance_code: c_int,
-    pub rb_roundtrips: size_t,
-    pub partial_pos_out: size_t,
-    pub symbol: u32,
-    pub repeat: u32,
-    pub space: u32,
-    pub table: [HuffmanCode; 32],
-    pub symbol_lists: *mut u16,
-    pub symbols_lists_array: [u16; 720],
-    pub next_symbol: [c_int; 32],
-    pub code_length_code_lengths: [u8; 18],
-    pub code_length_histo: [u16; 16],
-    pub htree_index: c_int,
-    pub next: *mut HuffmanCode,
-    pub context_index: u32,
-    pub max_run_length_prefix: u32,
-    pub code: u32,
-    pub context_map_table: [HuffmanCode; 646],
-    pub mtf_upper_bound: u32,
-    pub mtf: [u8; 260],
-    pub custom_dict: *const u8,
-    pub custom_dict_size: c_int,
-    pub substate_metablock_header: BrotliRunningMetablockHeaderState,
-    pub substate_tree_group: BrotliRunningTreeGroupState,
-    pub substate_context_map: BrotliRunningContextMapState,
-    pub substate_uncompressed: BrotliRunningUncompressedState,
-    pub substate_huffman: BrotliRunningHuffmanState,
-    pub substate_decode_uint8: BrotliRunningDecodeUint8State,
-    pub substate_read_block_length: BrotliRunningReadBlockLengthState,
-    pub is_last_metablock: u8,
-    pub is_uncompressed: u8,
-    pub is_metadata: u8,
-    pub size_nibbles: u8,
-    pub window_bits: u32,
-    pub num_literal_htrees: u32,
-    pub context_map: *mut u8,
-    pub context_modes: *mut u8,
-    pub trivial_literal_contexts: [u32; 8],
-}
+pub const BROTLI_DECODER_RESULT_ERROR: BrotliDecoderResult = 0;
+pub const BROTLI_DECODER_RESULT_SUCCESS: BrotliDecoderResult = 1;
+pub const BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT: BrotliDecoderResult = 2;
+pub const BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT: BrotliDecoderResult = 3;
 
-#[cfg(target_pointer_width = "32")]
-pub type reg_t = u32;
-#[cfg(target_pointer_width = "64")]
-pub type reg_t = u64;
+pub const BROTLI_DECODER_NO_ERROR: BrotliDecoderErrorCode = 0;
+pub const BROTLI_DECODER_SUCCESS: BrotliDecoderErrorCode = 1;
+pub const BROTLI_DECODER_NEEDS_MORE_INPUT: BrotliDecoderErrorCode = 2;
+pub const BROTLI_DECODER_NEEDS_MORE_OUTPUT: BrotliDecoderErrorCode = 3;
+pub const BROTLI_DECODER_ERROR_FORMAT_EXUBERANT_NIBBLE: BrotliDecoderErrorCode = -1;
+pub const BROTLI_DECODER_ERROR_FORMAT_RESERVED: BrotliDecoderErrorCode = -2;
+pub const BROTLI_DECODER_ERROR_FORMAT_EXUBERANT_META_NIBBLE: BrotliDecoderErrorCode = -3;
+pub const BROTLI_DECODER_ERROR_FORMAT_SIMPLE_HUFFMAN_ALPHABET: BrotliDecoderErrorCode = -4;
+pub const BROTLI_DECODER_ERROR_FORMAT_SIMPLE_HUFFMAN_SAME: BrotliDecoderErrorCode = -5;
+pub const BROTLI_DECODER_ERROR_FORMAT_CL_SPACE: BrotliDecoderErrorCode = -6;
+pub const BROTLI_DECODER_ERROR_FORMAT_HUFFMAN_SPACE: BrotliDecoderErrorCode = -7;
+pub const BROTLI_DECODER_ERROR_FORMAT_CONTEXT_MAP_REPEAT: BrotliDecoderErrorCode = -8;
+pub const BROTLI_DECODER_ERROR_FORMAT_BLOCK_LENGTH_1: BrotliDecoderErrorCode = -9;
+pub const BROTLI_DECODER_ERROR_FORMAT_BLOCK_LENGTH_2: BrotliDecoderErrorCode = -10;
+pub const BROTLI_DECODER_ERROR_FORMAT_TRANSFORM: BrotliDecoderErrorCode = -11;
+pub const BROTLI_DECODER_ERROR_FORMAT_DICTIONARY: BrotliDecoderErrorCode = -12;
+pub const BROTLI_DECODER_ERROR_FORMAT_WINDOW_BITS: BrotliDecoderErrorCode = -13;
+pub const BROTLI_DECODER_ERROR_FORMAT_PADDING_1: BrotliDecoderErrorCode = -14;
+pub const BROTLI_DECODER_ERROR_FORMAT_PADDING_2: BrotliDecoderErrorCode = -15;
+pub const BROTLI_DECODER_ERROR_INVALID_ARGUMENTS: BrotliDecoderErrorCode = -20;
+pub const BROTLI_DECODER_ERROR_ALLOC_CONTEXT_MODES: BrotliDecoderErrorCode = -21;
+pub const BROTLI_DECODER_ERROR_ALLOC_TREE_GROUPS: BrotliDecoderErrorCode = -22;
+pub const BROTLI_DECODER_ERROR_ALLOC_CONTEXT_MAP: BrotliDecoderErrorCode = -25;
+pub const BROTLI_DECODER_ERROR_ALLOC_RING_BUFFER_1: BrotliDecoderErrorCode = -26;
+pub const BROTLI_DECODER_ERROR_ALLOC_RING_BUFFER_2: BrotliDecoderErrorCode = -27;
+pub const BROTLI_DECODER_ERROR_ALLOC_BLOCK_TYPE_TREES: BrotliDecoderErrorCode = -30;
+pub const BROTLI_DECODER_ERROR_UNREACHABLE: BrotliDecoderErrorCode = -31;
 
-#[repr(C)]
-pub struct BrotliBitReader {
-    pub val_: reg_t,
-    pub bit_pos_: u32,
-    pub next_in: *const u8,
-    pub avail_in: size_t,
-}
-
-#[repr(C)]
-pub struct HuffmanCode {
-    pub bits: u8,
-    pub value: u16,
-}
-
-#[repr(C)]
-pub struct HuffmanTreeGroup {
-    pub htrees: *mut *mut HuffmanCode,
-    pub codes: *mut HuffmanCode,
-    pub alphabet_size: u16,
-    pub num_htrees: u16,
-}
-
-pub const BROTLI_RESULT_ERROR: BrotliResult = 0;
-pub const BROTLI_RESULT_SUCCESS: BrotliResult = 1;
-pub const BROTLI_RESULT_NEEDS_MORE_INPUT: BrotliResult = 2;
-pub const BROTLI_RESULT_NEEDS_MORE_OUTPUT: BrotliResult = 3;
-
-extern {
-    // BrotliState
-    pub fn BrotliCreateState(alloc_func: Option<brotli_alloc_func>,
-                             free_func: Option<brotli_free_func>,
-                             opaque: *mut c_void) -> *mut BrotliState;
-    pub fn BrotliDestroyState(state: *mut BrotliState);
-    pub fn BrotliDecompressedSize(encoded_size: size_t,
-                                  encoded_buff: *const u8,
-                                  decoded_size: *mut size_t) -> c_int;
-    pub fn BrotliDecompressBuffer(encoded_size: size_t,
-                                  encoded_buffer: *const u8,
-                                  decoded_size: *mut size_t,
-                                  decoded_buffer: *mut u8) -> BrotliResult;
-    pub fn BrotliDecompressStream(available_in: *mut size_t,
-                                  next_in: *mut *const u8,
-                                  available_out: *mut size_t,
-                                  next_out: *mut *mut u8,
-                                  total_out: *mut size_t,
-                                  s: *mut BrotliState) -> BrotliResult;
-    pub fn BrotliSetCustomDictionary(size: size_t,
-                                     dict: *const u8,
-                                     s: *mut BrotliState);
-
-    // raw state
-    pub fn BrotliStateInit(s: *mut BrotliState);
-    pub fn BrotliStateInitWithCustomAllocators(s: *mut BrotliState,
-                                               alloc_func: brotli_alloc_func,
-                                               free_func: brotli_free_func,
-                                               opaque: *mut c_void);
-    pub fn BrotliStateCleanup(s: *mut BrotliState);
-    pub fn BrotliStateMetablockBegin(s: *mut BrotliState);
-    pub fn BrotliStateCleanupAfterMetablock(s: *mut BrotliState);
-    pub fn BrotliHuffmanTreeGroupInit(s: *mut BrotliState,
-                                      group: *mut HuffmanTreeGroup,
-                                      alphabet_size: u32,
-                                      ntrees: u32);
-    pub fn BrotliHuffmanTreeGroupRelease(s: *mut BrotliState,
-                                         group: *mut HuffmanTreeGroup);
-    pub fn BrotliStateIsStreamStart(s: *const BrotliState) -> c_int;
-    pub fn BrotliStateIsStreamEnd(s: *const BrotliState) -> c_int;
-
-    // huffman
-    pub fn BrotliBuildCodeLengthsHuffmanTable(root_table: *mut HuffmanCode,
-                                              code_lengths: *const u8,
-                                              count: *mut u16);
-    pub fn BrotliBuildHuffmanTable(root_table: *mut HuffmanCode,
-                                   root_bits: c_int,
-                                   symbol_lists: *const u16,
-                                   count_arg: *mut u16) -> u32;
-    pub fn BrotliBuildSimpleHuffmanTable(table: *mut HuffmanCode,
-                                         root_bits: c_int,
-                                         symbols: *mut u16,
-                                         num_symbols: u32) -> u32;
+extern "C" {
+    pub fn BrotliDecoderCreateInstance(alloc_func: brotli_alloc_func,
+                                       free_func: brotli_free_func,
+                                       opaque: *mut c_void)
+                                       -> *mut BrotliDecoderState;
+    pub fn BrotliDecoderDestroyInstance(state: *mut BrotliDecoderState);
+    pub fn BrotliDecoderDecompress(encoded_size: size_t,
+                                   encoded_buffer: *const u8,
+                                   decoded_size: *mut size_t,
+                                   decoded_buffer: *mut u8) ->
+                                   BrotliDecoderResult;
+    pub fn BrotliDecoderDecompressStream(state: *mut BrotliDecoderState,
+                                         available_in: *mut size_t,
+                                         next_in: *mut *const u8,
+                                         available_out: *mut size_t,
+                                         next_out: *mut *mut u8,
+                                         total_out: *mut size_t)
+                                         -> BrotliDecoderResult;
+    pub fn BrotliDecoderSetCustomDictionary(state: *mut BrotliDecoderState,
+                                            size: size_t,
+                                            dict: *const u8);
+    pub fn BrotliDecoderHasMoreOutput(state: *const BrotliDecoderState) -> c_int;
+    pub fn BrotliDecoderTakeOutput(state: *mut BrotliDecoderState,
+                                   size: *mut size_t)
+                                   -> *const u8;
+    pub fn BrotliDecoderIsUsed(state: *const BrotliDecoderState) -> c_int;
+    pub fn BrotliDecoderIsFinished(state: *const BrotliDecoderState) -> c_int;
+    pub fn BrotliDecoderGetErrorCode(state: *const BrotliDecoderState) -> BrotliDecoderErrorCode;
+    pub fn BrotliDecoderErrorString(c: BrotliDecoderErrorCode) -> *const c_char;
+    pub fn BrotliDecoderVersion() -> u32;
 }
 
 
@@ -221,10 +105,13 @@ pub const BROTLI_PARAM_MODE: BrotliEncoderParameter = 0;
 pub const BROTLI_PARAM_QUALITY: BrotliEncoderParameter = 1;
 pub const BROTLI_PARAM_LGWIN: BrotliEncoderParameter = 2;
 pub const BROTLI_PARAM_LGBLOCK: BrotliEncoderParameter = 3;
+pub const BROTLI_PARAM_DISABLE_LITERAL_CONTEXT_MODELING: BrotliEncoderParameter = 4;
+pub const BROTLI_PARAM_SIZE_HINT: BrotliEncoderParameter = 5;
 
 pub const BROTLI_OPERATION_PROCESS: BrotliEncoderOperation = 0;
 pub const BROTLI_OPERATION_FLUSH: BrotliEncoderOperation = 1;
 pub const BROTLI_OPERATION_FINISH: BrotliEncoderOperation = 2;
+pub const BROTLI_OPERATION_EMIT_METADATA: BrotliEncoderOperation = 3;
 
 pub const BROTLI_DEFAULT_QUALITY: u32 = 11;
 pub const BROTLI_DEFAULT_WINDOW: u32 = 22;
@@ -232,35 +119,18 @@ pub const BROTLI_DEFAULT_MODE: u32 = 0;
 
 pub enum BrotliEncoderState {}
 
-extern {
+extern "C" {
     pub fn BrotliEncoderSetParameter(state: *mut BrotliEncoderState,
-                                     p: BrotliEncoderParameter,
+                                     param: BrotliEncoderParameter,
                                      value: u32)
                                      -> c_int;
-    pub fn BrotliEncoderCreateInstance(alloc_func: Option<brotli_alloc_func>,
-                                       free_func: Option<brotli_free_func>,
+    pub fn BrotliEncoderCreateInstance(alloc_func: brotli_alloc_func,
+                                       free_func: brotli_free_func,
                                        opaque: *mut c_void)
                                        -> *mut BrotliEncoderState;
     pub fn BrotliEncoderDestroyInstance(state: *mut BrotliEncoderState);
+    // Next three are deprecated, but we use them
     pub fn BrotliEncoderInputBlockSize(state: *mut BrotliEncoderState) -> size_t;
-    pub fn BrotliEncoderWriteMetaBlock(state: *mut BrotliEncoderState,
-                                       input_size: size_t,
-                                       input_buffer: *const u8,
-                                       is_last: c_int,
-                                       encoded_size: *mut size_t,
-                                       encoded_buffer: *mut u8)
-                                       -> c_int;
-    pub fn BrotliEncoderWriteMetadata(state: *mut BrotliEncoderState,
-                                      input_size: size_t,
-                                      input_buffer: *const u8,
-                                      is_last: c_int,
-                                      encoded_size: *mut size_t,
-                                      encoded_buffer: *mut u8)
-                                      -> c_int;
-    pub fn BrotliEncoderFinishStream(state: *mut BrotliEncoderState,
-                                     encoded_size: *mut size_t,
-                                     encoded_buffer: *mut u8)
-                                     -> c_int;
     pub fn BrotliEncoderCopyInputToRingBuffer(state: *mut BrotliEncoderState,
                                               input_size: size_t,
                                               input_buffer: *const u8);
@@ -282,7 +152,7 @@ extern {
                                  encoded_size: *mut size_t,
                                  encoded_buffer: *mut u8)
                                  -> c_int;
-    pub fn BrotliEncoderCompressStream(s: *mut BrotliEncoderState,
+    pub fn BrotliEncoderCompressStream(state: *mut BrotliEncoderState,
                                        op: BrotliEncoderOperation,
                                        available_in: *mut size_t,
                                        next_in: *mut *const u8,
@@ -290,6 +160,10 @@ extern {
                                        next_out: *mut *mut u8,
                                        total_out: *mut size_t)
                                        -> c_int;
-    pub fn BrotliEncoderIsFinished(s: *mut BrotliEncoderState) -> c_int;
-    pub fn BrotliEncoderHasMoreOutput(s: *mut BrotliEncoderState) -> c_int;
+    pub fn BrotliEncoderIsFinished(state: *mut BrotliEncoderState) -> c_int;
+    pub fn BrotliEncoderHasMoreOutput(state: *mut BrotliEncoderState) -> c_int;
+    pub fn BrotliEncoderTakeOutput(state: *mut BrotliEncoderState,
+                                   size: *mut usize)
+                                   -> *const u8;
+    pub fn BrotliEncoderVersion() -> u32;
 }

--- a/examples/all-read-write-roundtrips.rs
+++ b/examples/all-read-write-roundtrips.rs
@@ -1,0 +1,94 @@
+extern crate brotli2;
+extern crate rand;
+
+use std::io::{Read, Write};
+use brotli2::read;
+use brotli2::write;
+use brotli2::stream::{CompressParams, compress_buf, decompress_buf};
+use rand::Rng;
+use rand::SeedableRng;
+
+// Used in functions as temporary storage space before producing a vec
+const BIGBUF_SIZE: usize = 120*1024*1024;
+static mut BIGBUF: [u8; BIGBUF_SIZE] = [0; BIGBUF_SIZE];
+
+fn main() {
+    let v1 = vec![1; 1024];
+    let v2 = vec![44; 10*1024*1024];
+    let datas: &[&[u8]] = &[
+        b"",
+        b"a",
+        b"aaaaa",
+        b";",
+        &v1,
+        &v2,
+    ];
+    let mut params = CompressParams::new();
+    params.quality(6);
+    let params = &params;
+
+    fn bufencode(data: &[u8], params: &CompressParams) -> Vec<u8> {
+        let bufref = &mut unsafe { &mut BIGBUF[..] };
+        let n = compress_buf(params, data, bufref).unwrap();
+        assert!(n > 0 && n <= BIGBUF_SIZE && n == bufref.len());
+        bufref.to_owned()
+    }
+    fn bufdecode(data: &[u8]) -> Vec<u8> {
+        let bufref = &mut unsafe { &mut BIGBUF[..] };
+        let n = decompress_buf(data, bufref).unwrap();
+        assert!(n <= BIGBUF_SIZE && n == bufref.len());
+        bufref.to_owned()
+    }
+    fn ioreadencode(data: &[u8], params: &CompressParams) -> Vec<u8> {
+        let mut buf = vec![];
+        read::BrotliEncoder::from_params(data, params).read_to_end(&mut buf).unwrap();
+        assert!(buf.len() > 0);
+        buf
+    }
+    fn ioreaddecode (data: &[u8]) -> Vec<u8> {
+        let mut buf = vec![];
+        read::BrotliDecoder::new(data).read_to_end(&mut buf).unwrap();
+        buf
+    }
+    fn iowriteencode(data: &[u8], params: &CompressParams) -> Vec<u8> {
+        let mut enc = write::BrotliEncoder::from_params(vec![], params);
+        enc.write_all(data).unwrap();
+        enc.finish().unwrap()
+    }
+    fn iowritedecode(data: &[u8]) -> Vec<u8> {
+        let mut dec = write::BrotliDecoder::new(vec![]);
+        dec.write_all(data).unwrap();
+        dec.finish().unwrap()
+    }
+
+    let check = |data: &[u8]| {
+        let c1 = &bufencode(data, params);
+        let c2 = &ioreadencode(data, params);
+        let c3 = &iowriteencode(data, params);
+        assert!(data == &*bufdecode(c1));
+        assert!(data == &*ioreaddecode(c1));
+        assert!(data == &*iowritedecode(c1));
+        // it's valid for them to be different, but we need to do more work
+        if c2 != c1 {
+            assert!(data == &*bufdecode(c2));
+            assert!(data == &*ioreaddecode(c2));
+            assert!(data == &*iowritedecode(c2));
+        }
+        if c3 != c1 && c3 != c2 {
+            assert!(data == &*bufdecode(c2));
+            assert!(data == &*ioreaddecode(c2));
+            assert!(data == &*iowritedecode(c2));
+        }
+    };
+
+    for &data in datas.iter() {
+        check(data)
+    }
+    let mut rng = rand::XorShiftRng::from_seed([1, 4, 55, 98]);
+    for _ in 0..3 {
+        let rnum: usize = rng.gen_range(1, 100*1024*1024);
+        let mut buf = vec![0; rnum];
+        rng.fill_bytes(&mut buf);
+        check(&buf)
+    }
+}

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -3,27 +3,21 @@ extern crate ctest;
 use std::env;
 
 fn main() {
-    let dec_include = env::var("DEP_BROTLI_DEC_INCLUDE").unwrap();
-    let enc_include = env::var("DEP_BROTLI_ENC_INCLUDE").unwrap();
+    let include = env::var("DEP_BROTLI_INCLUDE").unwrap();
     let mut cfg = ctest::TestGenerator::new();
 
     if env::var("TARGET").unwrap().contains("msvc") {
         cfg.flag("/wd2220"); // allow "no object file was generated"
         cfg.flag("/wd4127"); // allow "conditional expression is constant"
         cfg.flag("/wd4464"); // allow "relative include path contains '..'"
+    } else {
+        cfg.flag("-Wno-deprecated-declarations");
     }
-    cfg.header("decode.h")
-       .header("encode.h")
-       .header("state.h");
-    cfg.include(&dec_include).include(&enc_include);
-    cfg.type_name(|s, _| {
-        if s == "BrotliStateStruct" {
-            format!("struct BrotliStateStruct")
-        } else {
-            s.to_string()
-        }
-    });
-    cfg.skip_type(|n| n == "__enum_ty");
-    cfg.skip_signededness(|s| s.ends_with("_func") || s == "BrotliState");
+    cfg.header("brotli/decode.h")
+       .header("brotli/encode.h");
+    cfg.include(&include);
+    cfg.type_name(|s, _| s.to_string());
+    cfg.skip_type(|n| n == "__enum_ty" || n == "__enum_ty_s");
+    cfg.skip_signededness(|s| s.ends_with("_func"));
     cfg.generate("../brotli-sys/src/lib.rs", "all.rs");
 }

--- a/systest/src/main.rs
+++ b/systest/src/main.rs
@@ -3,7 +3,6 @@
 extern crate brotli_sys;
 extern crate libc;
 
-use libc::*;
 use brotli_sys::*;
 
 include!(concat!(env!("OUT_DIR"), "/all.rs"));


### PR DESCRIPTION
As a side effect, the bindings have become much simplified because they don't need to contain all the internal details of the decoder struct any more.

Some thoughts before merging

1. `BrotliDecompressedSize` is [gone](https://github.com/google/brotli/commit/f20b3eeb2f401fc4b87488ca22ca32729a6dec20#diff-1721da9a2c189d371911e516cdd0b5b1L1302) with no replacement. This means I've removed the `decompressed_size` method, which doesn't make me too sad since the comment seemed to basicaly say "this isn't reliable". On the other hand, it's backwards incompatible. If we really wanted to preserve this rather than bump version, we could ask the brotli project if they plan to add anything back.
2. I've removed some commented out methods using APIs that were deprecated and are now removed.
3. The API we're now making use of is deprecated (as revealed by `ctest`, which I've not come across before and is nifty), so I've disabled deprecated warnings for now. I've only done this on non-msvc because a look at `ctest` seems to indicate that this warning is [disabled by default](https://github.com/alexcrichton/ctest/blob/0b7f7b707add9d10c85bd3911030f7a739c349fa/src/lib.rs#L567) for msvc for some reason (been there since the initial commit)? (I've not actually tested msvc)
4. I've added a few TODOs for using the newer APIs (`BrotliEncoderCompressStream` function for compression, more compression parameters, human readable errors when decoding) that didn't seem particularly crucial for this upgrade.