### PR TITLE
Use new compressor API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_script:
 script:
   - export CARGO_TARGET_DIR=`pwd`/target
   - cargo test
+  - cargo run --example all-read-write-roundtrips --release
   - cargo run --manifest-path systest/Cargo.toml
   - cargo doc --no-deps
   - cargo doc --no-deps --manifest-path=brotli-sys/Cargo.toml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,4 +14,5 @@ build: false
 
 test_script:
   - cargo test --target %TARGET%
+  - cargo run --example all-read-write-roundtrips --release --target %TARGET%
   - cargo run --manifest-path systest/Cargo.toml --target %TARGET%

--- a/brotli-sys/src/lib.rs
+++ b/brotli-sys/src/lib.rs
@@ -129,17 +129,17 @@ extern "C" {
                                        opaque: *mut c_void)
                                        -> *mut BrotliEncoderState;
     pub fn BrotliEncoderDestroyInstance(state: *mut BrotliEncoderState);
-    // Next three are deprecated, but we use them
-    pub fn BrotliEncoderInputBlockSize(state: *mut BrotliEncoderState) -> size_t;
-    pub fn BrotliEncoderCopyInputToRingBuffer(state: *mut BrotliEncoderState,
-                                              input_size: size_t,
-                                              input_buffer: *const u8);
-    pub fn BrotliEncoderWriteData(state: *mut BrotliEncoderState,
-                                  is_last: c_int,
-                                  force_flush: c_int,
-                                  out_size: *mut size_t,
-                                  output: *mut *mut u8)
-                                  -> c_int;
+    // These three are deprecated
+    //pub fn BrotliEncoderInputBlockSize(state: *mut BrotliEncoderState) -> size_t;
+    //pub fn BrotliEncoderCopyInputToRingBuffer(state: *mut BrotliEncoderState,
+    //                                          input_size: size_t,
+    //                                          input_buffer: *const u8);
+    //pub fn BrotliEncoderWriteData(state: *mut BrotliEncoderState,
+    //                              is_last: c_int,
+    //                              force_flush: c_int,
+    //                              out_size: *mut size_t,
+    //                              output: *mut *mut u8)
+    //                              -> c_int;
     pub fn BrotliEncoderSetCustomDictionary(state: *mut BrotliEncoderState,
                                             size: size_t,
                                             dict: *const u8);

--- a/examples/all-read-write-roundtrips.rs
+++ b/examples/all-read-write-roundtrips.rs
@@ -4,7 +4,8 @@ extern crate rand;
 use std::io::{Read, Write};
 use brotli2::read;
 use brotli2::write;
-use brotli2::stream::{CompressParams, compress_buf, decompress_buf};
+use brotli2::CompressParams;
+use brotli2::raw::{compress_buf, decompress_buf};
 use rand::Rng;
 use rand::SeedableRng;
 

--- a/src/bufread.rs
+++ b/src/bufread.rs
@@ -3,7 +3,8 @@
 use std::io::prelude::*;
 use std::io;
 
-use stream::{self, Decompress, DeStatus, Compress, CompressOp, CompressParams, CoStatus};
+use super::CompressParams;
+use raw::{self, Decompress, DeStatus, Compress, CompressOp, CoStatus};
 
 #[derive(Clone, Copy, Eq, PartialEq)]
 enum DoneStatus {
@@ -20,7 +21,7 @@ pub struct BrotliEncoder<R: BufRead> {
     obj: R,
     data: Compress,
     done: DoneStatus,
-    err: Option<stream::Error>,
+    err: Option<raw::Error>,
 }
 
 /// A brotli decoder, or decompressor.
@@ -30,7 +31,7 @@ pub struct BrotliEncoder<R: BufRead> {
 pub struct BrotliDecoder<R: BufRead> {
     obj: R,
     data: Decompress,
-    err: Option<stream::Error>,
+    err: Option<raw::Error>,
 }
 
 impl<R: BufRead> BrotliEncoder<R> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,101 @@ extern crate rand;
 #[cfg(test)]
 extern crate quickcheck;
 
-pub mod stream;
+pub mod raw;
 pub mod bufread;
 pub mod read;
 pub mod write;
+
+/// Possible choices for modes of compression
+#[repr(isize)]
+#[derive(Copy,Clone,Debug,PartialEq,Eq)]
+pub enum CompressMode {
+    /// Default compression mode, the compressor does not know anything in
+    /// advance about the properties of the input.
+    Generic = brotli_sys::BROTLI_MODE_GENERIC as isize,
+    /// Compression mode for utf-8 formatted text input.
+    Text = brotli_sys::BROTLI_MODE_TEXT as isize,
+    /// Compression mode in WOFF 2.0.
+    Font = brotli_sys::BROTLI_MODE_FONT as isize,
+}
+
+/// Parameters passed to various compression routines.
+#[derive(Clone,Debug)]
+pub struct CompressParams {
+    /// Compression mode.
+    mode: u32,
+    /// Controls the compression-speed vs compression-density tradeoffs. The higher the `quality`,
+    /// the slower the compression. Range is 0 to 11.
+    quality: u32,
+    /// Base 2 logarithm of the sliding window size. Range is 10 to 24.
+    lgwin: u32,
+    /// Base 2 logarithm of the maximum input block size. Range is 16 to 24. If set to 0, the value
+    /// will be set based on the quality.
+    lgblock: u32,
+}
+
+impl CompressParams {
+    /// Creates a new default set of compression parameters.
+    pub fn new() -> CompressParams {
+        CompressParams {
+            mode: brotli_sys::BROTLI_DEFAULT_MODE,
+            quality: brotli_sys::BROTLI_DEFAULT_QUALITY,
+            lgwin: brotli_sys::BROTLI_DEFAULT_WINDOW,
+            lgblock: 0,
+        }
+    }
+
+    /// Set the mode of this compression.
+    pub fn mode(&mut self, mode: CompressMode) -> &mut CompressParams {
+        self.mode = mode as u32;
+        self
+    }
+
+    /// Controls the compression-speed vs compression-density tradeoffs.
+    ///
+    /// The higher the quality, the slower the compression. Currently the range
+    /// for the quality is 0 to 11.
+    pub fn quality(&mut self, quality: u32) -> &mut CompressParams {
+        self.quality = quality;
+        self
+    }
+
+    /// Sets the base 2 logarithm of the sliding window size.
+    ///
+    /// Currently the range is 10 to 24.
+    pub fn lgwin(&mut self, lgwin: u32) -> &mut CompressParams {
+        self.lgwin = lgwin;
+        self
+    }
+
+    /// Sets the base 2 logarithm of the maximum input block size.
+    ///
+    /// Currently the range is 16 to 24, and if set to 0 the value will be set
+    /// based on the quality.
+    pub fn lgblock(&mut self, lgblock: u32) -> &mut CompressParams {
+        self.lgblock = lgblock;
+        self
+    }
+
+    /// Get the current block size
+    #[inline]
+    pub fn get_lgblock_readable(&self) -> usize {
+        1usize << self.lgblock
+    }
+
+    /// Get the native lgblock size
+    #[inline]
+    pub fn get_lgblock(&self) -> u32 {
+        self.lgblock.clone()
+    }
+    /// Get the current window size
+    #[inline]
+    pub fn get_lgwin_readable(&self) -> usize {
+        1usize << self.lgwin
+    }
+    /// Get the native lgwin value
+    #[inline]
+    pub fn get_lgwin(&self) -> u32 {
+        self.lgwin.clone()
+    }
+}

--- a/src/read.rs
+++ b/src/read.rs
@@ -3,8 +3,9 @@
 use std::io::prelude::*;
 use std::io::{self, BufReader};
 
-use stream::CompressParams;
 use bufread;
+
+use super::CompressParams;
 
 /// A compression stream which wraps an uncompressed stream of data. Compressed
 /// data will be read from the stream.

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -48,7 +48,7 @@ pub struct CompressParams {
 
 /// Possible choices for modes of compression
 #[repr(isize)]
-#[derive(Copy,Clone,Debug)]
+#[derive(Copy,Clone,Debug,PartialEq,Eq)]
 pub enum CompressMode {
     /// Default compression mode, the compressor does not know anything in
     /// advance about the properties of the input.
@@ -59,13 +59,49 @@ pub enum CompressMode {
     Font = brotli_sys::BROTLI_MODE_FONT as isize,
 }
 
+/// Possible choices for the operation performed by the compressor.
+///
+/// When using any operation except `Process`, you must *not* alter the
+/// input buffer or use a different operation until the current operation
+/// has 'completed'. An operation may need to be repeated with more space to
+/// write data until it can complete.
+#[repr(isize)]
+#[derive(Copy,Clone,Debug,PartialEq,Eq)]
+pub enum CompressOp {
+    /// Compress input data
+    Process = brotli_sys::BROTLI_OPERATION_PROCESS as isize,
+    /// Compress input data, ensuring that all input so far has been
+    /// written out
+    Flush = brotli_sys::BROTLI_OPERATION_FLUSH as isize,
+    /// Compress input data, ensuring that all input so far has been
+    /// written out and then finalizing the stream so no more data can
+    /// be written
+    Finish = brotli_sys::BROTLI_OPERATION_FINISH as isize,
+    /// Emit a metadata block to the stream, an opaque piece of out-of-band
+    /// data that does not interfere with the main stream of data. Metadata
+    /// blocks *must* be no longer than 16MiB
+    EmitMetadata = brotli_sys::BROTLI_OPERATION_EMIT_METADATA as isize,
+}
+
 /// Error that can happen from decompressing or compressing a brotli stream.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Error(());
 
-/// Possible status results returned from compressing or decompressing.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum Status {
+/// Indication of whether a compression operation is 'complete'. This does
+/// not indicate whether the whole stream is complete - see `Compress::compress`
+/// for details.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CoStatus {
+    /// The operation completed successfully
+    Finished,
+    /// The operation has more work to do and needs to be called again with the
+    /// same buffer
+    Unfinished,
+}
+
+/// Possible status results returned from decompressing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeStatus {
     /// Decompression was successful and has finished
     Finished,
     /// More input is needed to continue
@@ -85,7 +121,7 @@ impl Decompress {
         }
     }
 
-    /// Decompress a block of input data into a block of output data.
+    /// Decompress some input data and write it to a buffer of output data.
     ///
     /// This function will decompress the data in `input` and place the output
     /// in `output`, returning the result. Possible statuses that can be
@@ -102,7 +138,7 @@ impl Decompress {
     /// returned.
     pub fn decompress(&mut self,
                       input: &mut &[u8],
-                      output: &mut &mut [u8]) -> Result<Status, Error> {
+                      output: &mut &mut [u8]) -> Result<DeStatus, Error> {
         let mut available_in = input.len();
         let mut next_in = input.as_ptr();
         let mut available_out = output.len();
@@ -122,38 +158,32 @@ impl Decompress {
         Decompress::rc(r)
     }
 
-    /// Decompress a block of input data into the remaining capacity of a
-    /// vector.
-    ///
-    /// This function is the same as `decompress` except that it will fill up
-    /// the remaining capacity in a destination vector and update the length as
-    /// necessary.
-    pub fn decompress_vec(&mut self,
-                          input: &mut &[u8],
-                          output: &mut Vec<u8>) -> Result<Status, Error> {
-        let cap = output.capacity();
-        let len = output.len();
-
+    /// Retrieve a slice of the internal decompressor buffer up to `size_limit` in length
+    /// (unlimited length if `None`), consuming it. As the internal buffer may not be
+    /// contiguous, consecutive calls may return more output until this function returns
+    /// `None`.
+    pub fn take_output(&mut self, size_limit: Option<usize>) -> Option<&[u8]> {
+        if let Some(0) = size_limit { return None }
+        let mut size_limit = size_limit.unwrap_or(0); // 0 now means unlimited
         unsafe {
-            let (ret, remaining) = {
-                let ptr = output.as_mut_ptr().offset(len as isize);
-                let mut out = slice::from_raw_parts_mut(ptr, cap - len);
-                let r = self.decompress(input, &mut out);
-                (r, out.len())
-            };
-            output.set_len(cap - remaining);
-            return ret
+            let ptr = brotli_sys::BrotliDecoderTakeOutput(self.state, &mut size_limit);
+            if size_limit == 0 { // ptr may or may not be null
+                None
+            } else {
+                assert!(!ptr.is_null());
+                Some(slice::from_raw_parts(ptr, size_limit))
+            }
         }
     }
 
-    fn rc(rc: brotli_sys::BrotliDecoderResult) -> Result<Status, Error> {
+    fn rc(rc: brotli_sys::BrotliDecoderResult) -> Result<DeStatus, Error> {
         match rc {
             // TODO: get info from BrotliDecoderGetErrorCode/BrotliDecoderErrorString
             // for these decode errors
             brotli_sys::BROTLI_DECODER_RESULT_ERROR => Err(Error(())),
-            brotli_sys::BROTLI_DECODER_RESULT_SUCCESS => Ok(Status::Finished),
-            brotli_sys::BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT => Ok(Status::NeedInput),
-            brotli_sys::BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT => Ok(Status::NeedOutput),
+            brotli_sys::BROTLI_DECODER_RESULT_SUCCESS => Ok(DeStatus::Finished),
+            brotli_sys::BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT => Ok(DeStatus::NeedInput),
+            brotli_sys::BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT => Ok(DeStatus::NeedOutput),
             n => panic!("unknown return code: {}", n)
         }
     }
@@ -199,62 +229,56 @@ impl Compress {
         }
     }
 
-    /// Returns the maximum amount of data that can be internally buffered to
-    /// get processed at once.
-    ///
-    /// Data is fed into this compressor via the `copy_input` function, and then
-    /// it's later compressed via the `write_brotli_data` function.
-    pub fn input_block_size(&self) -> usize {
-        unsafe { brotli_sys::BrotliEncoderInputBlockSize(self.state) }
-    }
-
     // TODO: add the BrotliEncoderOperation variants of
     // BrotliEncoderCompressStream here
 
-    /// Feeds data into this compressor.
+    /// Pass some input data to the compressor and write it to a buffer of
+    /// output data, compressing or otherwise handling it as instructed by
+    /// the specified operation.
     ///
-    /// This compressor can store up to `self.input_block_size()` bytes
-    /// internally after which the `compress` call must be made to generate all
-    /// output of the compressor.
+    /// This function will handle the data in `input` and place the output
+    /// in `output`, returning the Result. Possible statuses are that the
+    /// operation is complete or incomplete.
     ///
-    /// If too much data is copied in then the next call to `compress` will
-    /// generate an error.
-    pub fn copy_input(&mut self, input: &[u8]) {
-        unsafe {
-            brotli_sys::BrotliEncoderCopyInputToRingBuffer(self.state,
-                                                           input.len(),
-                                                           input.as_ptr())
-        }
-    }
-
-    /// Compresses the internal data in this compressor, returning the output
-    /// buffer of the compressed data.
+    /// The `input` slice is updated to point to the remaining data that was not
+    /// consumed, and the `output` slice is updated to point to the portion of
+    /// the output slice that still needs to be filled in.
     ///
-    /// After data has been fed to this compressor via the `copy_input` method,
-    /// the data is then compressed by calling this method. The `last` flag
-    /// indicates whether this is the last block of the input (it should only
-    /// get passed on EOF), and the `force_flush` flag indicates whether a new
-    /// meta-block should be created to flush the internal data.
+    /// If the result of a compress operation is `Unfinished` (which it may be
+    /// for any operation except `Process`), you *must* call the operation again
+    /// with the same operation and input buffer and more space to output to.
+    /// `Process` will never return `Unfinished`, but it is a logic error to end
+    /// a buffer without calling either `Flush` or `Finish` as some output data
+    /// may not have been written.
     ///
-    /// Returns an error, if any, and otherwise the internal buffer which
-    /// contains the output data of compressed information.
+    /// # Errors
+    ///
+    /// Returns an error if brotli encountered an error while processing the stream.
     ///
     /// # Examples
     ///
     /// ```
-    /// use std::cmp;
-    /// use brotli2::stream::{Error, Compress, decompress_buf};
+    /// use brotli2::stream::{Error, Compress, CompressOp, CoStatus, decompress_buf};
     ///
     /// // An example of compressing `input` into the destination vector
-    /// // `output`
-    /// fn compress_vec(input: &[u8],
+    /// // `output`, expanding as necessary
+    /// fn compress_vec(mut input: &[u8],
     ///                 output: &mut Vec<u8>) -> Result<(), Error> {
     ///     let mut compress = Compress::new();
-    ///     for chunk in input.chunks(compress.input_block_size()) {
-    ///         compress.copy_input(chunk);
-    ///         output.extend_from_slice(&try!(compress.compress(false, false)));
+    ///     let nilbuf = &mut &mut [][..];
+    ///     loop {
+    ///         // Compressing to a buffer is easiest when the slice is already
+    ///         // available - since we need to grow, extend from compressor
+    ///         // internal buffer.
+    ///         let status = try!(compress.compress(CompressOp::Finish, &mut input, nilbuf));
+    ///         while let Some(buf) = compress.take_output(None) {
+    ///             output.extend_from_slice(buf)
+    ///         }
+    ///         match status {
+    ///             CoStatus::Finished => break,
+    ///             CoStatus::Unfinished => (),
+    ///         }
     ///     }
-    ///     output.extend_from_slice(&try!(compress.compress(true, false)));
     ///     Ok(())
     /// }
     ///
@@ -272,23 +296,56 @@ impl Compress {
     /// assert_roundtrip(b"");
     /// assert_roundtrip(&[6; 1024]);
     /// ```
-    pub fn compress(&mut self, last: bool, force_flush: bool)
-                    -> Result<&[u8], Error> {
-        let mut size = 0;
-        let mut ptr = 0 as *mut _;
+    pub fn compress(&mut self,
+                    op: CompressOp,
+                    input: &mut &[u8],
+                    output: &mut &mut [u8]) -> Result<CoStatus, Error> {
+        let mut available_in = input.len();
+        let mut next_in = input.as_ptr();
+        let mut available_out = output.len();
+        let mut next_out = output.as_mut_ptr();
+        let mut total_out = 0;
+        let r = unsafe {
+            brotli_sys::BrotliEncoderCompressStream(self.state,
+                                                    op as brotli_sys::BrotliEncoderOperation,
+                                                    &mut available_in,
+                                                    &mut next_in,
+                                                    &mut available_out,
+                                                    &mut next_out,
+                                                    &mut total_out)
+        };
+        *input = &input[input.len() - available_in..];
+        let out_len = output.len();
+        *output = &mut mem::replace(output, &mut [])[out_len - available_out..];
+        if r == 0 { return Err(Error(())) }
+        Ok(if op == CompressOp::Process {
+            CoStatus::Finished
+        } else if available_in != 0 {
+            CoStatus::Unfinished
+        } else if unsafe { brotli_sys::BrotliEncoderHasMoreOutput(self.state) } == 1 {
+            CoStatus::Unfinished
+        } else if op == CompressOp::Finish &&
+                unsafe { brotli_sys::BrotliEncoderIsFinished(self.state) } == 0 {
+            CoStatus::Unfinished
+        } else {
+            CoStatus::Finished
+        })
+    }
+
+    /// Retrieve a slice of the internal compressor buffer up to `size_limit` in length
+    /// (unlimited length if `None`), consuming it. As the internal buffer may not be
+    /// contiguous, consecutive calls may return more output until this function returns
+    /// `None`.
+    pub fn take_output(&mut self, size_limit: Option<usize>) -> Option<&[u8]> {
+        if let Some(0) = size_limit { return None }
+        let mut size_limit = size_limit.unwrap_or(0); // 0 now means unlimited
         unsafe {
-            let (last, flush) = (last as c_int, force_flush as c_int);
-            let r = brotli_sys::BrotliEncoderWriteData(self.state,
-                                                       last,
-                                                       flush,
-                                                       &mut size,
-                                                       &mut ptr);
-            if r == 0 {
-                Err(Error(()))
-            } else if size == 0 {
-                Ok(slice::from_raw_parts_mut(1 as *mut _, size))
+            let ptr = brotli_sys::BrotliEncoderTakeOutput(self.state, &mut size_limit);
+            if size_limit == 0 { // ptr may or may not be null
+                None
             } else {
-                Ok(slice::from_raw_parts_mut(ptr, size))
+                assert!(!ptr.is_null());
+                Some(slice::from_raw_parts(ptr, size_limit))
             }
         }
     }
@@ -469,7 +526,7 @@ mod tests {
     }
 
     #[test]
-    fn decompressor_smoke() {
+    fn decompress_smoke() {
         let mut data = [0; 128];
         let mut data = &mut data[..];
         compress_buf(&CompressParams::new(), b"hello!", &mut data).unwrap();
@@ -479,36 +536,36 @@ mod tests {
         {
             let mut data = &data[..];
             let mut dst = &mut dst[..];
-            assert_eq!(d.decompress(&mut data, &mut dst), Ok(Status::Finished));
+            assert_eq!(d.decompress(&mut data, &mut dst), Ok(DeStatus::Finished));
         }
         assert_eq!(&dst[..6], b"hello!");
-
-        let mut d = Decompress::new();
-        let mut dst = Vec::with_capacity(10);
-        assert_eq!(d.decompress_vec(&mut &data[..], &mut dst),
-                   Ok(Status::Finished));
-        assert_eq!(&dst, b"hello!");
     }
 
     #[test]
     fn compress_smoke() {
-        let mut data = Vec::new();
-        let mut c = Compress::new();
-        c.copy_input(b"hello!");
-        data.extend_from_slice(c.compress(true, false).unwrap());
-
+        let mut data = [0; 128];
         let mut dst = [0; 128];
+
+        {
+            let mut data = &mut data[..];
+            let mut c = Compress::new();
+            let mut input = &mut &b"hello!"[..];
+            assert_eq!(c.compress(CompressOp::Finish, input, &mut data), Ok(CoStatus::Finished));
+            assert!(input.is_empty());
+        }
         decompress_buf(&data, &mut &mut dst[..]).unwrap();
         assert_eq!(&dst[..6], b"hello!");
 
-        data.truncate(0);
-        let mut c = Compress::new();
-        c.copy_input(b"hel");
-        data.extend_from_slice(c.compress(false, true).unwrap());
-        c.copy_input(b"lo!");
-        data.extend_from_slice(c.compress(true, false).unwrap());
-
-        let mut dst = [0; 128];
+        {
+            let mut data = &mut data[..];
+            let mut c = Compress::new();
+            let mut input = &mut &b"hel"[..];
+            assert_eq!(c.compress(CompressOp::Flush, input, &mut data), Ok(CoStatus::Finished));
+            assert!(input.is_empty());
+            let mut input = &mut &b"lo!"[..];
+            assert_eq!(c.compress(CompressOp::Finish, input, &mut data), Ok(CoStatus::Finished));
+            assert!(input.is_empty());
+        }
         decompress_buf(&data, &mut &mut dst[..]).unwrap();
         assert_eq!(&dst[..6], b"hello!");
     }

--- a/src/write.rs
+++ b/src/write.rs
@@ -3,7 +3,9 @@
 use std::io::prelude::*;
 use std::io;
 
-use stream::{self, Decompress, DeStatus, Compress, CompressOp, CoStatus, CompressParams};
+use raw::{self, Decompress, DeStatus, Compress, CompressOp, CoStatus};
+
+use super::CompressParams;
 
 const BUF_SIZE: usize = 32 * 1024;
 
@@ -14,7 +16,7 @@ pub struct BrotliEncoder<W: Write> {
     obj: Option<W>,
     buf: Vec<u8>,
     cur: usize,
-    err: Option<stream::Error>,
+    err: Option<raw::Error>,
 }
 
 /// A compression stream which will have compressed data written to it and
@@ -24,7 +26,7 @@ pub struct BrotliDecoder<W: Write> {
     obj: Option<W>,
     buf: Vec<u8>,
     cur: usize,
-    err: Option<stream::Error>,
+    err: Option<raw::Error>,
 }
 
 impl<W: Write> BrotliEncoder<W> {

--- a/src/write.rs
+++ b/src/write.rs
@@ -68,7 +68,13 @@ impl<W: Write> BrotliEncoder<W> {
             }
             // TODO: if we could peek, the buffer wouldn't be necessary
             if let Some(data) = self.data.take_output(Some(BUF_SIZE)) {
-                self.buf.extend_from_slice(data)
+                match self.obj.as_mut().unwrap().write(data) {
+                    Ok(n) => self.buf.extend_from_slice(&data[n..]),
+                    Err(e) => {
+                        self.buf.extend_from_slice(data);
+                        return Err(e)
+                    }
+                }
             } else {
                 break
             }

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -10,8 +10,6 @@ fn main() {
         cfg.flag("/wd2220"); // allow "no object file was generated"
         cfg.flag("/wd4127"); // allow "conditional expression is constant"
         cfg.flag("/wd4464"); // allow "relative include path contains '..'"
-    } else {
-        cfg.flag("-Wno-deprecated-declarations");
     }
     cfg.header("brotli/decode.h")
        .header("brotli/encode.h");


### PR DESCRIPTION
Followup to #10 once it gets merged. This is a WIP.

The new design of brotli seems a little odd, but I've tried to represent it as reasonably as possible. Some notes/thoughts so far:

 - I don't actually know if it's unsafe (i.e. may segfault) to disobey the documentation and choose a different op before the previous one is complete. Worth investigating?
 - Complete and Incomplete could be bools, but it seem clearer as an enum.
 - CoStatus/DeStatus vs CompressStatus/DecompressStatus - I chose the former for brevity, but don't have any real attachment to them.
 - Got rid of `decompress_vec`, since it looked like an internal method that got exposed in case others found it useful. Now it's not used internally, I feel like we should be pushing people towards the methods that correspond to the C API.
 - Fixed minor bug where finish did not actually flush the underlying write stream.

-----

After struggling for some time with it, I'd like to talk about the `Write` trait. As it stands, it's seems extremely difficult to implement it as described in [the documentation](https://doc.rust-lang.org/std/io/trait.Write.html). There are two quotes of interest for the `write` method:

1. "A call to write represents at most one attempt to write to any wrapped object."
2. "If an error is returned then no bytes in the buffer were written to this writer."

There are two possible interpretations of 1:

a. 'You can only call `write` once on each wrapped object'
b. 'If a call to write fails, you're not allowed to retry'

The implications of these are as follows

1a. Not allowed call `write` multiple times, so `write_all` is clearly forbidden. As we need to ship data to a writer which may be slower than data is coming in, you either need an unbounded buffer or the ability to use `Ok(0)` to indicate you're flushing some data.
1b. Not allowed to use `write_all` as it masks `Interrupted`. But you can replace it with your own `write_all` that bubbles up any error, so this isn't too problematic.

Now let's completely ignore 1, and just consider 2. The implication here is that writes are 'retry-safe', i.e. if you get an error you can try again with the buffer you just tried with and if it succeeds then all is well. This forbids `write_all` as you can't keep track of where you were up to if an error occurs and you may have already written some of the buffer, making your code retry-unsafe.

So, `write_all` is basically forbidden by anyone implementing `Write` who wants to follow these rules. It turns out that the current implementation in this library uses `write_all`, but tries to be retry-safe - I am reasonably confident I can come up with a test that demonstrates this.

Looking up the original [IO RFC](https://github.com/rust-lang/rfcs/blob/master/text/0517-io-os-reform.md#revising-reader-and-writer), the intention seems to have been that both 1a *and* 1b are the desired interpretations. I contend that adhering to these three rules is not possible in a moderately complex writer. Let's take a look a zlib. [It mentions](https://github.com/alexcrichton/flate2-rs/blob/e3fd774/src/zio.rs#L144-L149) the issue I raise about `Ok(0)`, and of the three options for dealing with 1a (returning `Ok(0)`, using an unbounded buffer, ignoring the requirement) has opted for ignoring the requirement, happily attempting to write to a contained object more than once.

It's also worth talking about the interaction between 1b and 2 here. A naive implementer following these two rules might take input, process it, and attempt to write all the bytes out in a loop, keeping track of progress. If one of the writes fails, the implementer *must* return the number of bytes written and so the error needs to be stashed away until the next attempted operation when it can be bubbled up. This is horrible, but can be alleviated by the One True Way displayed in zlib - an inversion of the naive logic I describe above, with [fallible IO coming first](https://github.com/alexcrichton/flate2-rs/blob/e3fd774/src/zio.rs#L151), followed by consumption of the input buffer that will not fail on IO, effectively queuing the IO for the next call.

I'm just noting down my experiences (this is a terser version of a comment I lost) as I plan to:
 - make a micro-rfc to amend the documentation of the `Write` trait to make 1a 'best effort'
 - add a (desperately-needed) example of the inversion described above to the `Write` trait page